### PR TITLE
Update jquery.datetimepicker.css

### DIFF
--- a/jquery.datetimepicker.css
+++ b/jquery.datetimepicker.css
@@ -11,7 +11,7 @@
 	padding-left: 0;
 	padding-top: 2px;
 	position: absolute;
-	z-index: 9999;
+	z-index: 65537;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	display: none;


### PR DESCRIPTION
Bumping the base z-index one unit higher than that for anti:modals (65536) ensures the picker will still be visible when embedded in an anti:modal template.
